### PR TITLE
[AMRSW-1346] add dynamic_reconfigure for min_acceleration.

### DIFF
--- a/diff_drive_controller/cfg/DiffDriveController.cfg
+++ b/diff_drive_controller/cfg/DiffDriveController.cfg
@@ -15,4 +15,7 @@ gen.add("wheel_separation_multiplier", double_t, 0, "Wheel separation multiplier
 gen.add("publish_rate", double_t, 0, "Publish rate of odom.", 50.0, 0.0, 2000.0)
 gen.add("enable_odom_tf", bool_t, 0, "Publish odom frame to tf.", True)
 
+# Control parameters related
+gen.add("linear_min_acceleration", double_t, 0, "Minimum linear acceleration.", -1.0, -5.0, 5.0)
+
 exit(gen.generate(PACKAGE, "diff_drive_controller", "DiffDriveController"))

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -202,6 +202,8 @@ namespace diff_drive_controller{
       double publish_rate;
       bool enable_odom_tf;
 
+      double linear_min_acceleration;
+
       DynamicParams()
         : left_wheel_radius_multiplier(1.0)
         , right_wheel_radius_multiplier(1.0)
@@ -209,6 +211,7 @@ namespace diff_drive_controller{
         , publish_cmd(false)
         , publish_rate(50)
         , enable_odom_tf(true)
+        , linear_min_acceleration(-1.0)
       {}
 
       friend std::ostream& operator<<(std::ostream& os, const DynamicParams& params)
@@ -223,7 +226,10 @@ namespace diff_drive_controller{
            << "\tPublication parameters:\n"
            << "\t\tPublish executed velocity command: " << (params.publish_cmd?"enabled":"disabled") << "\n"
            << "\t\tPublication rate: " << params.publish_rate                 << "\n"
-           << "\t\tPublish frame odom on tf: " << (params.enable_odom_tf?"enabled":"disabled");
+           << "\t\tPublish frame odom on tf: " << (params.enable_odom_tf?"enabled":"disabled") << "\n"
+           //
+           << "\tControl parameters:\n"
+           << "\t\tLinear minimum acceleration: " << params.linear_min_acceleration;
 
         return os;
       }

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -364,6 +364,8 @@ namespace diff_drive_controller{
     dynamic_params.publish_rate = publish_rate;
     dynamic_params.enable_odom_tf = enable_odom_tf_;
 
+    dynamic_params.linear_min_acceleration = limiter_lin_.min_acceleration;
+
     dynamic_params_.writeFromNonRT(dynamic_params);
 
     // Initialize dynamic_reconfigure server
@@ -374,6 +376,8 @@ namespace diff_drive_controller{
 
     config.publish_rate = publish_rate;
     config.enable_odom_tf = enable_odom_tf_;
+
+    config.linear_min_acceleration = limiter_lin_.min_acceleration;
 
     dyn_reconf_server_ = std::make_shared<ReconfigureServer>(dyn_reconf_server_mutex_, controller_nh);
 
@@ -744,6 +748,8 @@ namespace diff_drive_controller{
 
     dynamic_params.enable_odom_tf = config.enable_odom_tf;
 
+    dynamic_params.linear_min_acceleration = config.linear_min_acceleration;
+
     dynamic_params_.writeFromNonRT(dynamic_params);
 
     ROS_INFO_STREAM_NAMED(name_, "Dynamic Reconfigure:\n" << dynamic_params);
@@ -757,6 +763,8 @@ namespace diff_drive_controller{
     left_wheel_radius_multiplier_  = dynamic_params.left_wheel_radius_multiplier;
     right_wheel_radius_multiplier_ = dynamic_params.right_wheel_radius_multiplier;
     wheel_separation_multiplier_   = dynamic_params.wheel_separation_multiplier;
+
+    limiter_lin_.min_acceleration = dynamic_params.linear_min_acceleration;
 
     publish_period_ = ros::Duration(1.0 / dynamic_params.publish_rate);
     enable_odom_tf_ = dynamic_params.enable_odom_tf;

--- a/diff_drive_controller/test/diff_drive_dyn_reconf_test.cpp
+++ b/diff_drive_controller/test/diff_drive_dyn_reconf_test.cpp
@@ -56,9 +56,9 @@ TEST_F(DiffDriveControllerTest, testDynReconfServerAlive)
     EXPECT_EQ(false, srv_resp.config.bools[0].value);
   }
 
-  EXPECT_EQ(4, srv_resp.config.doubles.size());
+  EXPECT_EQ(5, srv_resp.config.doubles.size());
 
-  if (srv_resp.config.doubles.size() >= 4)
+  if (srv_resp.config.doubles.size() >= 5)
   {
     EXPECT_EQ("left_wheel_radius_multiplier", srv_resp.config.doubles[0].name);
     EXPECT_EQ(1, srv_resp.config.doubles[0].value);
@@ -71,6 +71,9 @@ TEST_F(DiffDriveControllerTest, testDynReconfServerAlive)
 
     EXPECT_EQ("publish_rate", srv_resp.config.doubles[3].name);
     EXPECT_EQ(50, srv_resp.config.doubles[3].value);
+
+    EXPECT_EQ("linear_min_acceleration", srv_resp.config.doubles[4].name);
+    EXPECT_EQ(-1, srv_resp.config.doubles[4].value);
   }
 
   dynamic_reconfigure::DoubleParameter double_param;
@@ -94,6 +97,11 @@ TEST_F(DiffDriveControllerTest, testDynReconfServerAlive)
 
   srv_req.config.doubles.push_back(double_param);
 
+  double_param.name = "linear_min_acceleration";
+  double_param.value = -2;
+
+  srv_req.config.doubles.push_back(double_param);
+
   dynamic_reconfigure::BoolParameter bool_param;
   bool_param.name = "enable_odom_tf";
   bool_param.value = false;
@@ -111,9 +119,9 @@ TEST_F(DiffDriveControllerTest, testDynReconfServerAlive)
     EXPECT_EQ(false, srv_resp.config.bools[0].value);
   }
 
-  EXPECT_EQ(4, srv_resp.config.doubles.size());
+  EXPECT_EQ(5, srv_resp.config.doubles.size());
 
-  if (srv_resp.config.doubles.size() >= 4)
+  if (srv_resp.config.doubles.size() >= 5)
   {
     EXPECT_EQ("left_wheel_radius_multiplier", srv_resp.config.doubles[0].name);
     EXPECT_EQ(0.95, srv_resp.config.doubles[0].value);
@@ -126,6 +134,9 @@ TEST_F(DiffDriveControllerTest, testDynReconfServerAlive)
 
     EXPECT_EQ("publish_rate", srv_resp.config.doubles[3].name);
     EXPECT_EQ(150, srv_resp.config.doubles[3].value);
+
+    EXPECT_EQ("linear_min_acceleration", srv_resp.config.doubles[4].name);
+    EXPECT_EQ(-2, srv_resp.config.doubles[4].value);
   }
 }
 

--- a/diff_drive_controller/test/diffbot_controllers.yaml
+++ b/diff_drive_controller/test/diffbot_controllers.yaml
@@ -3,6 +3,7 @@ diffbot_controller:
   left_wheel: 'wheel_0_joint'
   right_wheel: 'wheel_1_joint'
   publish_rate: 50.0 # defaults to 50
+  linear/x/min_acceleration: -1.0
   pose_covariance_diagonal: [0.001, 0.001, 1000000.0, 1000000.0, 1000000.0, 1000.0]
   twist_covariance_diagonal: [0.001, 0.001, 1000000.0, 1000000.0, 1000000.0, 1000.0]
   cmd_vel_timeout: 20.0 # we test this separately, give plenty for the other tests


### PR DESCRIPTION
Close AMRSW-1346

## Description
Add dynamic_reconfigure for `min_acceleration` in `diff_drive_controller`. The purpose is to suppress the slippage in carrying heavy weight.

## Test
[Spread sheet](https://docs.google.com/spreadsheets/d/1biYjvwMFjrTs4bYaNwnvBlivI2HaS4ivFF_nRL_BPg0/edit?gid=0#gid=0)