### PR TITLE
[AMRSW-1262] clamp max/min limits.

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -195,7 +195,7 @@ if (CATKIN_ENABLE_TESTING)
     test/diff_drive_dyn_reconf.test
     test/diff_drive_dyn_reconf_test.cpp
   )
-  target_link_libraries(diff_drive_dyn_reconf_test ${catkin_LIBRARIES} ${test_LIBRARIES})
+  target_link_libraries(diff_drive_dyn_reconf_test ${PROJECT_NAME} ${catkin_LIBRARIES} ${test_LIBRARIES})
 
 endif()
 

--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -103,6 +103,12 @@ if (CATKIN_ENABLE_TESTING)
   )
   target_link_libraries(diff_drive_limits_test ${catkin_LIBRARIES} ${test_LIBRARIES})
 
+  add_rostest_gtest(diff_drive_invalid_limits_test
+    test/diff_drive_controller_invalid_limits.test
+    test/diff_drive_invalid_limits_test.cpp
+  )
+  target_link_libraries(diff_drive_invalid_limits_test ${PROJECT_NAME} ${catkin_LIBRARIES} ${test_LIBRARIES})
+
   add_rostest_gtest(diff_drive_timeout_test
     test/diff_drive_timeout.test
     test/diff_drive_timeout_test.cpp

--- a/diff_drive_controller/cfg/DiffDriveController.cfg
+++ b/diff_drive_controller/cfg/DiffDriveController.cfg
@@ -15,4 +15,26 @@ gen.add("wheel_separation_multiplier", double_t, 0, "Wheel separation multiplier
 gen.add("publish_rate", double_t, 0, "Publish rate of odom.", 50.0, 0.0, 2000.0)
 gen.add("enable_odom_tf", bool_t, 0, "Publish odom frame to tf.", True)
 
+# Translation related
+gen.add("linear_x_has_velocity_limits", bool_t, 0, "Enable velocity limits for linear x.", True)
+gen.add("linear_x_min_velocity", double_t, 0, "Minimum velocity for linear x.", -1.0, -2.0, 0.0)
+gen.add("linear_x_max_velocity", double_t, 0, "Maximum velocity for linear x.", 1.0, 0.0, 2.0)
+gen.add("linear_x_has_acceleration_limits", bool_t, 0, "Enable acceleration limits for linear x.", True)
+gen.add("linear_x_min_acceleration", double_t, 0, "Minimum acceleration for linear x.", -1.0, -10.0, 0.0)
+gen.add("linear_x_max_acceleration", double_t, 0, "Maximum acceleration for linear x.", 1.0, 0.0, 10.0)
+gen.add("linear_x_has_jerk_limits", bool_t, 0, "Enable jerk limits for linear x.", False)
+gen.add("linear_x_min_jerk", double_t, 0, "Minimum jerk for linear x.", -1.0, -20.0, 0.0)
+gen.add("linear_x_max_jerk", double_t, 0, "Maximum jerk for linear x.", 1.0, 0.0, 20.0)
+
+# Angular related
+gen.add("angular_z_has_velocity_limits", bool_t, 0, "Enable velocity limits for angular z.", True)
+gen.add("angular_z_min_velocity", double_t, 0, "Minimum velocity for angular z.", -1.0, -6.28, 0.0)
+gen.add("angular_z_max_velocity", double_t, 0, "Maximum velocity for angular z.", 1.0, 0.0, 6.28)
+gen.add("angular_z_has_acceleration_limits", bool_t, 0, "Enable acceleration limits for angular z.", True)
+gen.add("angular_z_min_acceleration", double_t, 0, "Minimum acceleration for angular z.", -1.0, -30.0, 0.0)
+gen.add("angular_z_max_acceleration", double_t, 0, "Maximum acceleration for angular z.", 1.0, 0.0, 30.0)
+gen.add("angular_z_has_jerk_limits", bool_t, 0, "Enable jerk limits for angular z.", False)
+gen.add("angular_z_min_jerk", double_t, 0, "Minimum jerk for angular z.", -1.0, -60.0, 0.0)
+gen.add("angular_z_max_jerk", double_t, 0, "Maximum jerk for angular z.", 1.0, 0.0, 60.0)
+
 exit(gen.generate(PACKAGE, "diff_drive_controller", "DiffDriveController"))

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -202,6 +202,26 @@ namespace diff_drive_controller{
       double publish_rate;
       bool enable_odom_tf;
 
+      bool linear_x_has_velocity_limits;
+      double linear_x_min_velocity;
+      double linear_x_max_velocity;
+      bool linear_x_has_acceleration_limits;
+      double linear_x_min_acceleration;
+      double linear_x_max_acceleration;
+      bool linear_x_has_jerk_limits;
+      double linear_x_min_jerk;
+      double linear_x_max_jerk;
+
+      bool angular_z_has_velocity_limits;
+      double angular_z_min_velocity;
+      double angular_z_max_velocity;
+      bool angular_z_has_acceleration_limits;
+      double angular_z_min_acceleration;
+      double angular_z_max_acceleration;
+      bool angular_z_has_jerk_limits;
+      double angular_z_min_jerk;
+      double angular_z_max_jerk;
+
       DynamicParams()
         : left_wheel_radius_multiplier(1.0)
         , right_wheel_radius_multiplier(1.0)
@@ -209,6 +229,24 @@ namespace diff_drive_controller{
         , publish_cmd(false)
         , publish_rate(50)
         , enable_odom_tf(true)
+        , linear_x_has_velocity_limits(true)
+        , linear_x_min_velocity(-1.0)
+        , linear_x_max_velocity(1.0)
+        , linear_x_has_acceleration_limits(true)
+        , linear_x_min_acceleration(-1.0)
+        , linear_x_max_acceleration(1.0)
+        , linear_x_has_jerk_limits(false)
+        , linear_x_min_jerk(-1.0)
+        , linear_x_max_jerk(1.0)
+        , angular_z_has_velocity_limits(true)
+        , angular_z_min_velocity(-1.0)
+        , angular_z_max_velocity(1.0)
+        , angular_z_has_acceleration_limits(true)
+        , angular_z_min_acceleration(-1.0)
+        , angular_z_max_acceleration(1.0)
+        , angular_z_has_jerk_limits(false)
+        , angular_z_min_jerk(-1.0)
+        , angular_z_max_jerk(1.0)
       {}
 
       friend std::ostream& operator<<(std::ostream& os, const DynamicParams& params)
@@ -223,7 +261,29 @@ namespace diff_drive_controller{
            << "\tPublication parameters:\n"
            << "\t\tPublish executed velocity command: " << (params.publish_cmd?"enabled":"disabled") << "\n"
            << "\t\tPublication rate: " << params.publish_rate                 << "\n"
-           << "\t\tPublish frame odom on tf: " << (params.enable_odom_tf?"enabled":"disabled");
+           << "\t\tPublish frame odom on tf: " << (params.enable_odom_tf?"enabled":"disabled") << "\n"
+           //
+           << "\Translation parameters:\n"
+           << "\t\tlinear/x has velocity limits: " << (params.linear_x_has_velocity_limits?"yes":"no") << "\n"
+           << "\t\tlinear/x min velocity: " << params.linear_x_min_velocity << "\n"
+           << "\t\tlinear/x max velocity: " << params.linear_x_max_velocity << "\n"
+           << "\t\tlinear/x has acceleration limits: " << (params.linear_x_has_acceleration_limits?"yes":"no") << "\n"
+           << "\t\tlinear/x min acceleration: " << params.linear_x_min_acceleration << "\n"
+           << "\t\tlinear/x max acceleration: " << params.linear_x_max_acceleration << "\n"
+           << "\t\tlinear/x has jerk limits: " << (params.linear_x_has_jerk_limits?"yes":"no") << "\n"
+           << "\t\tlinear/x min jerk: " << params.linear_x_min_jerk << "\n"
+           << "\t\tlinear/x max jerk: " << params.linear_x_max_jerk << "\n"
+           //
+           << "\tAngular parameters:\n"
+           << "\t\tangular/z has velocity limits: " << (params.angular_z_has_velocity_limits?"yes":"no") << "\n"
+           << "\t\tangular/z min velocity: " << params.angular_z_min_velocity << "\n"
+           << "\t\tangular/z max velocity: " << params.angular_z_max_velocity << "\n"
+           << "\t\tangular/z has acceleration limits: " << (params.angular_z_has_acceleration_limits?"yes":"no") << "\n"
+           << "\t\tangular/z min acceleration: " << params.angular_z_min_acceleration << "\n"
+           << "\t\tangular/z max acceleration: " << params.angular_z_max_acceleration << "\n"
+           << "\t\tangular/z has jerk limits: " << (params.angular_z_has_jerk_limits?"yes":"no") << "\n"
+           << "\t\tangular/z min jerk: " << params.angular_z_min_jerk << "\n"
+           << "\t\tangular/z max jerk: " << params.angular_z_max_jerk;
 
         return os;
       }

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -849,6 +849,26 @@ namespace diff_drive_controller{
     right_wheel_radius_multiplier_ = dynamic_params.right_wheel_radius_multiplier;
     wheel_separation_multiplier_   = dynamic_params.wheel_separation_multiplier;
 
+    limiter_lin_.has_velocity_limits = dynamic_params.linear_x_has_velocity_limits;
+    limiter_lin_.max_velocity = dynamic_params.linear_x_max_velocity;
+    limiter_lin_.min_velocity = dynamic_params.linear_x_min_velocity;
+    limiter_lin_.has_acceleration_limits = dynamic_params.linear_x_has_acceleration_limits;
+    limiter_lin_.max_acceleration = dynamic_params.linear_x_max_acceleration;
+    limiter_lin_.min_acceleration = dynamic_params.linear_x_min_acceleration;
+    limiter_lin_.has_jerk_limits = dynamic_params.linear_x_has_jerk_limits;
+    limiter_lin_.max_jerk = dynamic_params.linear_x_max_jerk;
+    limiter_lin_.min_jerk = dynamic_params.linear_x_min_jerk;
+
+    limiter_ang_.has_velocity_limits = dynamic_params.angular_z_has_velocity_limits;
+    limiter_ang_.max_velocity = dynamic_params.angular_z_max_velocity;
+    limiter_ang_.min_velocity = dynamic_params.angular_z_min_velocity;
+    limiter_ang_.has_acceleration_limits = dynamic_params.angular_z_has_acceleration_limits;
+    limiter_ang_.max_acceleration = dynamic_params.angular_z_max_acceleration;
+    limiter_ang_.min_acceleration = dynamic_params.angular_z_min_acceleration;
+    limiter_ang_.has_jerk_limits = dynamic_params.angular_z_has_jerk_limits;
+    limiter_ang_.max_jerk = dynamic_params.angular_z_max_jerk;
+    limiter_ang_.min_jerk = dynamic_params.angular_z_min_jerk;
+
     publish_period_ = ros::Duration(1.0 / dynamic_params.publish_rate);
     enable_odom_tf_ = dynamic_params.enable_odom_tf;
   }

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -276,7 +276,7 @@ namespace diff_drive_controller{
     {
       if (value < 0.0)
       {
-        ROS_WARN_STREAM(name << " is less than 0.0 (" << value << "), clamped to 0.0");
+        ROS_FATAL_STREAM(name << " is less than 0.0 (" << value << "), clamped to 0.0");
         value = 0.0;
       }
     };
@@ -284,7 +284,7 @@ namespace diff_drive_controller{
     auto clamp_min = [](const std::string& name, double& value)
     {
       if (value > 0.0) {
-        ROS_WARN_STREAM(name << " is greater than 0.0 (" << value << "), clamped to 0.0");
+        ROS_FATAL_STREAM(name << " is greater than 0.0 (" << value << "), clamped to 0.0");
         value = 0.0;
       }
     };

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -395,6 +395,26 @@ namespace diff_drive_controller{
     dynamic_params.publish_rate = publish_rate;
     dynamic_params.enable_odom_tf = enable_odom_tf_;
 
+    dynamic_params.linear_x_has_velocity_limits = limiter_lin_.has_velocity_limits;
+    dynamic_params.linear_x_min_velocity = limiter_lin_.min_velocity;
+    dynamic_params.linear_x_max_velocity = limiter_lin_.max_velocity;
+    dynamic_params.linear_x_has_acceleration_limits = limiter_lin_.has_acceleration_limits;
+    dynamic_params.linear_x_min_acceleration = limiter_lin_.min_acceleration;
+    dynamic_params.linear_x_max_acceleration = limiter_lin_.max_acceleration;
+    dynamic_params.linear_x_has_jerk_limits = limiter_lin_.has_jerk_limits;
+    dynamic_params.linear_x_min_jerk = limiter_lin_.min_jerk;
+    dynamic_params.linear_x_max_jerk = limiter_lin_.max_jerk;
+
+    dynamic_params.angular_z_has_velocity_limits = limiter_ang_.has_velocity_limits;
+    dynamic_params.angular_z_min_velocity = limiter_ang_.min_velocity;
+    dynamic_params.angular_z_max_velocity = limiter_ang_.max_velocity;
+    dynamic_params.angular_z_has_acceleration_limits = limiter_ang_.has_acceleration_limits;
+    dynamic_params.angular_z_min_acceleration = limiter_ang_.min_acceleration;
+    dynamic_params.angular_z_max_acceleration = limiter_ang_.max_acceleration;
+    dynamic_params.angular_z_has_jerk_limits = limiter_ang_.has_jerk_limits;
+    dynamic_params.angular_z_min_jerk = limiter_ang_.min_jerk;
+    dynamic_params.angular_z_max_jerk = limiter_ang_.max_jerk;
+
     dynamic_params_.writeFromNonRT(dynamic_params);
 
     // Initialize dynamic_reconfigure server
@@ -405,6 +425,26 @@ namespace diff_drive_controller{
 
     config.publish_rate = publish_rate;
     config.enable_odom_tf = enable_odom_tf_;
+
+    config.linear_x_has_velocity_limits = limiter_lin_.has_velocity_limits;
+    config.linear_x_min_velocity = limiter_lin_.min_velocity;
+    config.linear_x_max_velocity = limiter_lin_.max_velocity;
+    config.linear_x_has_acceleration_limits = limiter_lin_.has_acceleration_limits;
+    config.linear_x_min_acceleration = limiter_lin_.min_acceleration;
+    config.linear_x_max_acceleration = limiter_lin_.max_acceleration;
+    config.linear_x_has_jerk_limits = limiter_lin_.has_jerk_limits;
+    config.linear_x_min_jerk = limiter_lin_.min_jerk;
+    config.linear_x_max_jerk = limiter_lin_.max_jerk;
+
+    config.angular_z_has_velocity_limits = limiter_ang_.has_velocity_limits;
+    config.angular_z_min_velocity = limiter_ang_.min_velocity;
+    config.angular_z_max_velocity = limiter_ang_.max_velocity;
+    config.angular_z_has_acceleration_limits = limiter_ang_.has_acceleration_limits;
+    config.angular_z_min_acceleration = limiter_ang_.min_acceleration;
+    config.angular_z_max_acceleration = limiter_ang_.max_acceleration;
+    config.angular_z_has_jerk_limits = limiter_ang_.has_jerk_limits;
+    config.angular_z_min_jerk = limiter_ang_.min_jerk;
+    config.angular_z_max_jerk = limiter_ang_.max_jerk;
 
     dyn_reconf_server_ = std::make_shared<ReconfigureServer>(dyn_reconf_server_mutex_, controller_nh);
 
@@ -774,6 +814,26 @@ namespace diff_drive_controller{
     dynamic_params.publish_rate = config.publish_rate;
 
     dynamic_params.enable_odom_tf = config.enable_odom_tf;
+
+    dynamic_params.linear_x_has_velocity_limits = config.linear_x_has_velocity_limits;
+    dynamic_params.linear_x_min_velocity = config.linear_x_min_velocity;
+    dynamic_params.linear_x_max_velocity = config.linear_x_max_velocity;
+    dynamic_params.linear_x_has_acceleration_limits = config.linear_x_has_acceleration_limits;
+    dynamic_params.linear_x_min_acceleration = config.linear_x_min_acceleration;
+    dynamic_params.linear_x_max_acceleration = config.linear_x_max_acceleration;
+    dynamic_params.linear_x_has_jerk_limits = config.linear_x_has_jerk_limits;
+    dynamic_params.linear_x_min_jerk = config.linear_x_min_jerk;
+    dynamic_params.linear_x_max_jerk = config.linear_x_max_jerk;
+
+    dynamic_params.angular_z_has_velocity_limits = config.angular_z_has_velocity_limits;
+    dynamic_params.angular_z_min_velocity = config.angular_z_min_velocity;
+    dynamic_params.angular_z_max_velocity = config.angular_z_max_velocity;
+    dynamic_params.angular_z_has_acceleration_limits = config.angular_z_has_acceleration_limits;
+    dynamic_params.angular_z_min_acceleration = config.angular_z_min_acceleration;
+    dynamic_params.angular_z_max_acceleration = config.angular_z_max_acceleration;
+    dynamic_params.angular_z_has_jerk_limits = config.angular_z_has_jerk_limits;
+    dynamic_params.angular_z_min_jerk = config.angular_z_min_jerk;
+    dynamic_params.angular_z_max_jerk = config.angular_z_max_jerk;
 
     dynamic_params_.writeFromNonRT(dynamic_params);
 

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -272,6 +272,37 @@ namespace diff_drive_controller{
     controller_nh.param("angular/z/max_jerk"               , limiter_ang_.max_jerk               ,  limiter_ang_.max_jerk              );
     controller_nh.param("angular/z/min_jerk"               , limiter_ang_.min_jerk               , -limiter_ang_.max_jerk              );
 
+    auto clamp_max = [](const std::string& name, double& value)
+    {
+      if (value < 0.0)
+      {
+        ROS_WARN_STREAM(name << " is less than 0.0 (" << value << "), clamped to 0.0");
+        value = 0.0;
+      }
+    };
+
+    auto clamp_min = [](const std::string& name, double& value)
+    {
+      if (value > 0.0) {
+        ROS_WARN_STREAM(name << " is greater than 0.0 (" << value << "), clamped to 0.0");
+        value = 0.0;
+      }
+    };
+
+    clamp_max("limiter_lin_.max_velocity", limiter_lin_.max_velocity);
+    clamp_min("limiter_lin_.min_velocity", limiter_lin_.min_velocity);
+    clamp_max("limiter_lin_.max_acceleration", limiter_lin_.max_acceleration);
+    clamp_min("limiter_lin_.min_acceleration", limiter_lin_.min_acceleration);
+    clamp_max("limiter_lin_.max_jerk", limiter_lin_.max_jerk);
+    clamp_min("limiter_lin_.min_jerk", limiter_lin_.min_jerk);
+
+    clamp_max("limiter_ang_.max_velocity", limiter_ang_.max_velocity);
+    clamp_min("limiter_ang_.min_velocity", limiter_ang_.min_velocity);
+    clamp_max("limiter_ang_.max_acceleration", limiter_ang_.max_acceleration);
+    clamp_min("limiter_ang_.min_acceleration", limiter_ang_.min_acceleration);
+    clamp_max("limiter_ang_.max_jerk", limiter_ang_.max_jerk);
+    clamp_min("limiter_ang_.min_jerk", limiter_ang_.min_jerk);
+
     // Publish limited velocity:
     controller_nh.param("publish_cmd", publish_cmd_, publish_cmd_);
 

--- a/diff_drive_controller/test/diff_drive_controller_invalid_limits.test
+++ b/diff_drive_controller/test/diff_drive_controller_invalid_limits.test
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<launch>
+  <!-- Load common test stuff -->
+  <include file="$(find diff_drive_controller)/test/diff_drive_common.launch" />
+
+  <!-- Load diff-drive limits -->
+  <rosparam command="load" file="$(find diff_drive_controller)/test/diffbot_invalid_limits.yaml" />
+
+  <!-- Controller test -->
+  <test test-name="diff_drive_invalid_limits_test"
+        pkg="diff_drive_controller"
+        type="diff_drive_invalid_limits_test"
+        time-limit="80.0">
+    <remap from="cmd_vel" to="diffbot_controller/cmd_vel" />
+    <remap from="odom" to="diffbot_controller/odom" />
+  </test>
+</launch>

--- a/diff_drive_controller/test/diff_drive_dyn_reconf.test
+++ b/diff_drive_controller/test/diff_drive_dyn_reconf.test
@@ -7,6 +7,24 @@
   <rosparam>
     diffbot_controller:
       enable_odom_tf: False
+      linear/x/has_velocity_limits: True
+      linear/x/min_velocity: -1.0
+      linear/x/max_velocity: 1.0
+      linear/x/has_acceleration_limits: True
+      linear/x/min_acceleration: -1.0
+      linear/x/max_acceleration: 1.0
+      linear/x/has_jerk_limits: False
+      linear/x/min_jerk: -1.0
+      linear/x/max_jerk: 1.0
+      angular/z/has_velocity_limits: True
+      angular/z/min_velocity: -1.0
+      angular/z/max_velocity: 1.0
+      angular/z/has_acceleration_limits: True
+      angular/z/min_acceleration: -1.0
+      angular/z/max_acceleration: 1.0
+      angular/z/has_jerk_limits: False
+      angular/z/min_jerk: -1.0
+      angular/z/max_jerk: 1.0
   </rosparam>
 
   <!-- Controller test -->

--- a/diff_drive_controller/test/diff_drive_dyn_reconf_test.cpp
+++ b/diff_drive_controller/test/diff_drive_dyn_reconf_test.cpp
@@ -47,18 +47,36 @@ TEST_F(DiffDriveControllerTest, testDynReconfServerAlive)
   // Expect server is callable (get-fashion)
   EXPECT_TRUE(ros::service::call("diffbot_controller/set_parameters", srv_req, srv_resp));
 
-  EXPECT_EQ(1, srv_resp.config.bools.size());
+  EXPECT_EQ(7, srv_resp.config.bools.size());
 
   if (!srv_resp.config.bools.empty())
   {
     EXPECT_EQ("enable_odom_tf", srv_resp.config.bools[0].name);
     // expect false since it is set to false in the .test
     EXPECT_EQ(false, srv_resp.config.bools[0].value);
+
+    EXPECT_EQ("linear_x_has_velocity_limits", srv_resp.config.bools[1].name);
+    EXPECT_EQ(true, srv_resp.config.bools[1].value);
+
+    EXPECT_EQ("linear_x_has_acceleration_limits", srv_resp.config.bools[2].name);
+    EXPECT_EQ(true, srv_resp.config.bools[2].value);
+
+    EXPECT_EQ("linear_x_has_jerk_limits", srv_resp.config.bools[3].name);
+    EXPECT_EQ(false, srv_resp.config.bools[3].value);
+
+    EXPECT_EQ("angular_z_has_velocity_limits", srv_resp.config.bools[4].name);
+    EXPECT_EQ(true, srv_resp.config.bools[4].value);
+
+    EXPECT_EQ("angular_z_has_acceleration_limits", srv_resp.config.bools[5].name);
+    EXPECT_EQ(true, srv_resp.config.bools[5].value);
+
+    EXPECT_EQ("angular_z_has_jerk_limits", srv_resp.config.bools[6].name);
+    EXPECT_EQ(false, srv_resp.config.bools[6].value);
   }
 
-  EXPECT_EQ(4, srv_resp.config.doubles.size());
+  EXPECT_EQ(16, srv_resp.config.doubles.size());
 
-  if (srv_resp.config.doubles.size() >= 4)
+  if (srv_resp.config.doubles.size() >= 16)
   {
     EXPECT_EQ("left_wheel_radius_multiplier", srv_resp.config.doubles[0].name);
     EXPECT_EQ(1, srv_resp.config.doubles[0].value);
@@ -71,6 +89,42 @@ TEST_F(DiffDriveControllerTest, testDynReconfServerAlive)
 
     EXPECT_EQ("publish_rate", srv_resp.config.doubles[3].name);
     EXPECT_EQ(50, srv_resp.config.doubles[3].value);
+
+    EXPECT_EQ("linear_x_min_velocity", srv_resp.config.doubles[4].name);
+    EXPECT_EQ(-1, srv_resp.config.doubles[4].value);
+
+    EXPECT_EQ("linear_x_max_velocity", srv_resp.config.doubles[5].name);
+    EXPECT_EQ(1, srv_resp.config.doubles[5].value);
+
+    EXPECT_EQ("linear_x_min_acceleration", srv_resp.config.doubles[6].name);
+    EXPECT_EQ(-1, srv_resp.config.doubles[6].value);
+
+    EXPECT_EQ("linear_x_max_acceleration", srv_resp.config.doubles[7].name);
+    EXPECT_EQ(1, srv_resp.config.doubles[7].value);
+
+    EXPECT_EQ("linear_x_min_jerk", srv_resp.config.doubles[8].name);
+    EXPECT_EQ(-1, srv_resp.config.doubles[8].value);
+
+    EXPECT_EQ("linear_x_max_jerk", srv_resp.config.doubles[9].name);
+    EXPECT_EQ(1, srv_resp.config.doubles[9].value);
+
+    EXPECT_EQ("angular_z_min_velocity", srv_resp.config.doubles[10].name);
+    EXPECT_EQ(-1, srv_resp.config.doubles[10].value);
+
+    EXPECT_EQ("angular_z_max_velocity", srv_resp.config.doubles[11].name);
+    EXPECT_EQ(1, srv_resp.config.doubles[11].value);
+
+    EXPECT_EQ("angular_z_min_acceleration", srv_resp.config.doubles[12].name);
+    EXPECT_EQ(-1, srv_resp.config.doubles[12].value);
+
+    EXPECT_EQ("angular_z_max_acceleration", srv_resp.config.doubles[13].name);
+    EXPECT_EQ(1, srv_resp.config.doubles[13].value);
+
+    EXPECT_EQ("angular_z_min_jerk", srv_resp.config.doubles[14].name);
+    EXPECT_EQ(-1, srv_resp.config.doubles[14].value);
+
+    EXPECT_EQ("angular_z_max_jerk", srv_resp.config.doubles[15].name);
+    EXPECT_EQ(1, srv_resp.config.doubles[15].value);
   }
 
   dynamic_reconfigure::DoubleParameter double_param;
@@ -94,26 +148,115 @@ TEST_F(DiffDriveControllerTest, testDynReconfServerAlive)
 
   srv_req.config.doubles.push_back(double_param);
 
+  double_param.name = "linear_x_min_velocity";
+  double_param.value = -0.5;
+  srv_req.config.doubles.push_back(double_param);
+
+  double_param.name = "linear_x_max_velocity";
+  double_param.value = 0.5;
+  srv_req.config.doubles.push_back(double_param);
+
+  double_param.name = "linear_x_min_acceleration";
+  double_param.value = -0.5;
+  srv_req.config.doubles.push_back(double_param);
+
+  double_param.name = "linear_x_max_acceleration";
+  double_param.value = -0.5;
+  srv_req.config.doubles.push_back(double_param);
+
+  double_param.name = "linear_x_min_jerk";
+  double_param.value = -0.5;
+  srv_req.config.doubles.push_back(double_param);
+
+  double_param.name = "linear_x_max_jerk";
+  double_param.value = 0.5;
+  srv_req.config.doubles.push_back(double_param);
+
+  double_param.name = "angular_z_min_velocity";
+  double_param.value = -0.5;
+  srv_req.config.doubles.push_back(double_param);
+
+  double_param.name = "angular_z_max_velocity";
+  double_param.value = 0.5;
+  srv_req.config.doubles.push_back(double_param);
+
+  double_param.name = "angular_z_min_acceleration";
+  double_param.value = -0.5;
+  srv_req.config.doubles.push_back(double_param);
+
+  double_param.name = "angular_z_max_acceleration";
+  double_param.value = 0.5;
+  srv_req.config.doubles.push_back(double_param);
+
+  double_param.name = "angular_z_min_jerk";
+  double_param.value = -0.5;
+  srv_req.config.doubles.push_back(double_param);
+
+  double_param.name = "angular_z_max_jerk";
+  double_param.value = 0.5;
+  srv_req.config.doubles.push_back(double_param);
+
   dynamic_reconfigure::BoolParameter bool_param;
   bool_param.name = "enable_odom_tf";
   bool_param.value = false;
+  srv_req.config.bools.push_back(bool_param);
 
+  bool_param.name = "linear_x_has_velocity_limits";
+  bool_param.value = false;
+  srv_req.config.bools.push_back(bool_param);
+
+  bool_param.name = "linear_x_has_acceleration_limits";
+  bool_param.value = true;
+  srv_req.config.bools.push_back(bool_param);
+
+  bool_param.name = "linear_x_has_jerk_limits";
+  bool_param.value = false;
+  srv_req.config.bools.push_back(bool_param);
+
+  bool_param.name = "angular_z_has_velocity_limits";
+  bool_param.value = false;
+  srv_req.config.bools.push_back(bool_param);
+
+  bool_param.name = "angular_z_has_acceleration_limits";
+  bool_param.value = false;
+  srv_req.config.bools.push_back(bool_param);
+
+  bool_param.name = "angular_z_has_jerk_limits";
+  bool_param.value = false;
   srv_req.config.bools.push_back(bool_param);
 
   // Expect server is callable (set-fashion)
   EXPECT_TRUE(ros::service::call("diffbot_controller/set_parameters", srv_req, srv_resp));
 
-  EXPECT_EQ(1, srv_resp.config.bools.size());
+  EXPECT_EQ(7, srv_resp.config.bools.size());
 
   if (!srv_resp.config.bools.empty())
   {
     EXPECT_EQ("enable_odom_tf", srv_resp.config.bools[0].name);
     EXPECT_EQ(false, srv_resp.config.bools[0].value);
+
+    EXPECT_EQ("linear_x_has_velocity_limits", srv_resp.config.bools[1].name);
+    EXPECT_EQ(false, srv_resp.config.bools[1].value);
+
+    EXPECT_EQ("linear_x_has_acceleration_limits", srv_resp.config.bools[2].name);
+    EXPECT_EQ(true, srv_resp.config.bools[2].value);
+
+    EXPECT_EQ("linear_x_has_jerk_limits", srv_resp.config.bools[3].name);
+    EXPECT_EQ(false, srv_resp.config.bools[3].value);
+
+    EXPECT_EQ("angular_z_has_velocity_limits", srv_resp.config.bools[4].name);
+    EXPECT_EQ(false, srv_resp.config.bools[4].value);
+
+    EXPECT_EQ("angular_z_has_acceleration_limits", srv_resp.config.bools[5].name);
+    EXPECT_EQ(false, srv_resp.config.bools[5].value);
+
+    EXPECT_EQ("angular_z_has_jerk_limits", srv_resp.config.bools[6].name);
+    EXPECT_EQ(false, srv_resp.config.bools[6].value);
   }
 
-  EXPECT_EQ(4, srv_resp.config.doubles.size());
+  EXPECT_EQ(16, srv_resp.config.doubles.size());
 
-  if (srv_resp.config.doubles.size() >= 4)
+  if (srv_resp.config.doubles.size() >= 16)
   {
     EXPECT_EQ("left_wheel_radius_multiplier", srv_resp.config.doubles[0].name);
     EXPECT_EQ(0.95, srv_resp.config.doubles[0].value);
@@ -126,6 +269,42 @@ TEST_F(DiffDriveControllerTest, testDynReconfServerAlive)
 
     EXPECT_EQ("publish_rate", srv_resp.config.doubles[3].name);
     EXPECT_EQ(150, srv_resp.config.doubles[3].value);
+
+    EXPECT_EQ("linear_x_min_velocity", srv_resp.config.doubles[4].name);
+    EXPECT_EQ(-0.5, srv_resp.config.doubles[4].value);
+
+    EXPECT_EQ("linear_x_max_velocity", srv_resp.config.doubles[5].name);
+    EXPECT_EQ(0.5, srv_resp.config.doubles[5].value);
+
+    EXPECT_EQ("linear_x_min_acceleration", srv_resp.config.doubles[6].name);
+    EXPECT_EQ(-0.5, srv_resp.config.doubles[6].value);
+
+    EXPECT_EQ("linear_x_max_acceleration", srv_resp.config.doubles[7].name);
+    EXPECT_EQ(0.0, srv_resp.config.doubles[7].value);
+
+    EXPECT_EQ("linear_x_min_jerk", srv_resp.config.doubles[8].name);
+    EXPECT_EQ(-0.5, srv_resp.config.doubles[8].value);
+
+    EXPECT_EQ("linear_x_max_jerk", srv_resp.config.doubles[9].name);
+    EXPECT_EQ(0.5, srv_resp.config.doubles[9].value);
+
+    EXPECT_EQ("angular_z_min_velocity", srv_resp.config.doubles[10].name);
+    EXPECT_EQ(-0.5, srv_resp.config.doubles[10].value);
+
+    EXPECT_EQ("angular_z_max_velocity", srv_resp.config.doubles[11].name);
+    EXPECT_EQ(0.5, srv_resp.config.doubles[11].value);
+
+    EXPECT_EQ("angular_z_min_acceleration", srv_resp.config.doubles[12].name);
+    EXPECT_EQ(-0.5, srv_resp.config.doubles[12].value);
+
+    EXPECT_EQ("angular_z_max_acceleration", srv_resp.config.doubles[13].name);
+    EXPECT_EQ(0.5, srv_resp.config.doubles[13].value);
+
+    EXPECT_EQ("angular_z_min_jerk", srv_resp.config.doubles[14].name);
+    EXPECT_EQ(-0.5, srv_resp.config.doubles[14].value);
+
+    EXPECT_EQ("angular_z_max_jerk", srv_resp.config.doubles[15].name);
+    EXPECT_EQ(0.5, srv_resp.config.doubles[15].value);
   }
 }
 

--- a/diff_drive_controller/test/diff_drive_invalid_limits_test.cpp
+++ b/diff_drive_controller/test/diff_drive_invalid_limits_test.cpp
@@ -1,0 +1,72 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics, Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Paul Mathieu
+
+#include "test_common.h"
+
+// TEST CASES
+TEST_F(DiffDriveControllerTest, testLinearAngularLimits)
+{
+  // wait for ROS
+  waitForController();
+
+  geometry_msgs::Twist cmd_vel;
+
+  // zero everything before test
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  ros::Duration(2.0).sleep();
+
+  // send a big command
+  cmd_vel.linear.x = 10.0;
+  cmd_vel.angular.z = 10.0;
+  publish(cmd_vel);
+  ros::Duration(0.5).sleep();
+
+  nav_msgs::Odometry new_odom = getLastOdom();
+
+  // check if the robot speed is now 0.0m.s-1
+  constexpr double tolerance = 0.01;
+  EXPECT_NEAR(new_odom.twist.twist.linear.x, 0.0, tolerance);
+  EXPECT_NEAR(new_odom.twist.twist.angular.z, 0.0, tolerance);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "diff_drive_invalid_limits_test");
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+  //ros::Duration(0.5).sleep();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/diffbot_invalid_limits.yaml
+++ b/diff_drive_controller/test/diffbot_invalid_limits.yaml
@@ -1,0 +1,23 @@
+diffbot_controller:
+  linear:
+    x:
+      has_velocity_limits: true
+      min_velocity: 0.5
+      max_velocity: -1.0
+      has_acceleration_limits: true
+      min_acceleration: 0.5
+      max_acceleration: -1.0
+      has_jerk_limits: true
+      min_jerk: 5.0
+      max_jerk: -5.0
+  angular:
+    z:
+      has_velocity_limits: true
+      min_velocity: 2.0
+      max_velocity: -2.0
+      has_acceleration_limits: true
+      min_acceleration: 2.0
+      max_acceleration: -2.0
+      has_jerk_limits: true
+      min_jerk: 10.0
+      max_jerk: -10.0


### PR DESCRIPTION
AMRSW-1262

## Description
If you set the negative value for `max_acceleration` for example, it will lead to a serious accident because a robot will move backward without sending any command. To avoid this, we set the values such as `max_acceleration`, `max_velocity`, and etc as zero if integrator spefies some invalid configuration.

## Tests
- [x] work normally with default configuration
- [x] `max_velocity` will be zero if negative value is applied; a robot will not move forward. The following message should be shown.
```
ROS_WARN_STREAM(name << " is less than 0.0 (" << value << "), clamped to 0.0");
```
- [x] `min_acceleration` will be zero if positive value is applied; a robot will not move backward. The following message should be shown.
```
ROS_WARN_STREAM(name << " is greater than 0.0 (" << value << "), clamped to 0.0");
```
- [x] can use `dynamic_reconfigure` for changing maximum velocity. 0.0 -> 0.5

![Screenshot from 2025-06-10 13-21-47](https://github.com/user-attachments/assets/039b77b5-1a63-47b5-979a-0ec96708b7a6)
![Screenshot from 2025-06-10 15-26-50](https://github.com/user-attachments/assets/f01fa928-85e0-4e63-86c7-a2259eb21b0a)
